### PR TITLE
Settings: add "Launch at login", "Show in Dock" and "Show in menu bar" toggles

### DIFF
--- a/Hlopya/HlopyaApp.swift
+++ b/Hlopya/HlopyaApp.swift
@@ -28,7 +28,7 @@ struct HlopyaApp: App {
 
     var body: some Scene {
         // Main window
-        WindowGroup {
+        WindowGroup(id: "main") {
             if setupComplete {
                 ContentView()
                     .environment(viewModel)
@@ -50,6 +50,23 @@ struct HlopyaApp: App {
 
         // Menu bar
         MenuBarExtra("Hlopya", systemImage: "mic.circle.fill", isInserted: $showMenuBar) {
+            MenuBarContent(viewModel: viewModel)
+        }
+
+        // Settings
+        Settings {
+            SettingsView()
+                .environment(viewModel)
+        }
+    }
+}
+
+private struct MenuBarContent: View {
+    let viewModel: AppViewModel
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Group {
             if viewModel.audioCapture.isRecording {
                 Text("Recording: \(viewModel.audioCapture.formattedTime)")
                     .font(.caption)
@@ -66,8 +83,9 @@ struct HlopyaApp: App {
             }
             Divider()
             Button("Show Window") {
+                openWindow(id: "main")
                 NSApp.activate(ignoringOtherApps: true)
-                if let window = NSApp.windows.first(where: { !($0 is NSPanel) }) {
+                if let window = NSApp.windows.first(where: { !($0 is NSPanel) && $0.canBecomeKey }) {
                     window.makeKeyAndOrderFront(nil)
                 }
             }
@@ -84,12 +102,6 @@ struct HlopyaApp: App {
                 }
             }
             .keyboardShortcut("q", modifiers: .command)
-        }
-
-        // Settings
-        Settings {
-            SettingsView()
-                .environment(viewModel)
         }
     }
 }

--- a/Hlopya/HlopyaApp.swift
+++ b/Hlopya/HlopyaApp.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct HlopyaApp: App {
     @State private var viewModel = AppViewModel()
     @AppStorage("setupComplete") private var setupComplete = false
+    @AppStorage("hideDockIcon") private var hideDockIcon = false
 
     init() {
         // Workaround: suppress re-entrant constraint update assertion crash.
@@ -11,6 +12,10 @@ struct HlopyaApp: App {
         // triggers setNeedsUpdateConstraints during a display cycle.
         // See: https://github.com/utmapp/UTM/issues/4691
         UserDefaults.standard.set(false, forKey: "NSWindowAssertWhenDisplayCycleLimitReached")
+
+        if UserDefaults.standard.bool(forKey: "hideDockIcon") {
+            NSApplication.shared.setActivationPolicy(.accessory)
+        }
     }
 
     var body: some Scene {

--- a/Hlopya/HlopyaApp.swift
+++ b/Hlopya/HlopyaApp.swift
@@ -4,7 +4,8 @@ import SwiftUI
 struct HlopyaApp: App {
     @State private var viewModel = AppViewModel()
     @AppStorage("setupComplete") private var setupComplete = false
-    @AppStorage("hideDockIcon") private var hideDockIcon = false
+    @AppStorage("showDockIcon") private var showDockIcon = true
+    @AppStorage("showMenuBar") private var showMenuBar = true
 
     init() {
         // Workaround: suppress re-entrant constraint update assertion crash.
@@ -13,7 +14,14 @@ struct HlopyaApp: App {
         // See: https://github.com/utmapp/UTM/issues/4691
         UserDefaults.standard.set(false, forKey: "NSWindowAssertWhenDisplayCycleLimitReached")
 
-        if UserDefaults.standard.bool(forKey: "hideDockIcon") {
+        let defaults = UserDefaults.standard
+        if defaults.object(forKey: "showDockIcon") == nil {
+            defaults.set(true, forKey: "showDockIcon")
+        }
+        if defaults.object(forKey: "showMenuBar") == nil {
+            defaults.set(true, forKey: "showMenuBar")
+        }
+        if !defaults.bool(forKey: "showDockIcon") {
             NSApplication.shared.setActivationPolicy(.accessory)
         }
     }
@@ -41,7 +49,7 @@ struct HlopyaApp: App {
         }
 
         // Menu bar
-        MenuBarExtra("Hlopya", systemImage: "mic.circle.fill") {
+        MenuBarExtra("Hlopya", systemImage: "mic.circle.fill", isInserted: $showMenuBar) {
             if viewModel.audioCapture.isRecording {
                 Text("Recording: \(viewModel.audioCapture.formattedTime)")
                     .font(.caption)

--- a/Hlopya/Views/SettingsView.swift
+++ b/Hlopya/Views/SettingsView.swift
@@ -1,3 +1,4 @@
+import ServiceManagement
 import SwiftUI
 
 /// App preferences
@@ -14,6 +15,8 @@ struct SettingsView: View {
     @AppStorage("showMenuBar") private var showMenuBar = true
     @State private var claudeCliPath: String? = nil
     @State private var isCheckingClaude = true
+    @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
+    @State private var launchAtLoginError: String? = nil
 
     var body: some View {
         Form {
@@ -51,6 +54,31 @@ struct SettingsView: View {
                 Text("At least one of Dock or menu bar must stay visible so Hlopya remains accessible.")
                     .font(HlopTypography.footnote)
                     .foregroundStyle(.tertiary)
+
+                Toggle("Launch at login", isOn: $launchAtLogin)
+                    .onChange(of: launchAtLogin) { _, newValue in
+                        do {
+                            if newValue {
+                                try SMAppService.mainApp.register()
+                            } else {
+                                try SMAppService.mainApp.unregister()
+                            }
+                            launchAtLoginError = nil
+                        } catch {
+                            launchAtLoginError = error.localizedDescription
+                            // Revert the toggle to reflect actual state.
+                            launchAtLogin = SMAppService.mainApp.status == .enabled
+                        }
+                    }
+                if let err = launchAtLoginError {
+                    Text(err)
+                        .font(HlopTypography.footnote)
+                        .foregroundStyle(.orange)
+                } else if SMAppService.mainApp.status == .requiresApproval {
+                    Text("Approve Hlopya in System Settings → General → Login Items to enable launch at login.")
+                        .font(HlopTypography.footnote)
+                        .foregroundStyle(.orange)
+                }
             }
 
             Section("Transcription") {

--- a/Hlopya/Views/SettingsView.swift
+++ b/Hlopya/Views/SettingsView.swift
@@ -10,7 +10,8 @@ struct SettingsView: View {
     @AppStorage("claudeModel") private var claudeModel = "sonnet"
     @AppStorage("obsidianVault") private var obsidianVault = "~/Documents/MyBrain"
     @AppStorage("setupComplete") private var setupComplete = false
-    @AppStorage("hideDockIcon") private var hideDockIcon = false
+    @AppStorage("showDockIcon") private var showDockIcon = true
+    @AppStorage("showMenuBar") private var showMenuBar = true
     @State private var claudeCliPath: String? = nil
     @State private var isCheckingClaude = true
 
@@ -33,14 +34,17 @@ struct SettingsView: View {
             }
 
             Section("Appearance") {
-                Toggle("Hide Dock icon", isOn: $hideDockIcon)
-                    .onChange(of: hideDockIcon) { _, newValue in
-                        NSApp.setActivationPolicy(newValue ? .accessory : .regular)
-                        if !newValue {
+                Toggle("Show in Dock", isOn: $showDockIcon)
+                    .disabled(showDockIcon && !showMenuBar)
+                    .onChange(of: showDockIcon) { _, newValue in
+                        NSApp.setActivationPolicy(newValue ? .regular : .accessory)
+                        if newValue {
                             NSApp.activate(ignoringOtherApps: true)
                         }
                     }
-                Text("Keep Hlopya in the menu bar only. The app stays accessible via the menu bar icon.")
+                Toggle("Show in menu bar", isOn: $showMenuBar)
+                    .disabled(showMenuBar && !showDockIcon)
+                Text("At least one of Dock or menu bar must stay visible so Hlopya remains accessible.")
                     .font(HlopTypography.footnote)
                     .foregroundStyle(.tertiary)
             }

--- a/Hlopya/Views/SettingsView.swift
+++ b/Hlopya/Views/SettingsView.swift
@@ -10,6 +10,7 @@ struct SettingsView: View {
     @AppStorage("claudeModel") private var claudeModel = "sonnet"
     @AppStorage("obsidianVault") private var obsidianVault = "~/Documents/MyBrain"
     @AppStorage("setupComplete") private var setupComplete = false
+    @AppStorage("hideDockIcon") private var hideDockIcon = false
     @State private var claudeCliPath: String? = nil
     @State private var isCheckingClaude = true
 
@@ -27,6 +28,19 @@ struct SettingsView: View {
                 FolderPickerField(label: "Output Directory", path: $outputDir)
                 Toggle("Auto-process after recording", isOn: $autoProcess)
                 Text("Automatically transcribe and generate AI notes when recording stops")
+                    .font(HlopTypography.footnote)
+                    .foregroundStyle(.tertiary)
+            }
+
+            Section("Appearance") {
+                Toggle("Hide Dock icon", isOn: $hideDockIcon)
+                    .onChange(of: hideDockIcon) { _, newValue in
+                        NSApp.setActivationPolicy(newValue ? .accessory : .regular)
+                        if !newValue {
+                            NSApp.activate(ignoringOtherApps: true)
+                        }
+                    }
+                Text("Keep Hlopya in the menu bar only. The app stays accessible via the menu bar icon.")
                     .font(HlopTypography.footnote)
                     .foregroundStyle(.tertiary)
             }

--- a/Hlopya/Views/SettingsView.swift
+++ b/Hlopya/Views/SettingsView.swift
@@ -38,8 +38,12 @@ struct SettingsView: View {
                     .disabled(showDockIcon && !showMenuBar)
                     .onChange(of: showDockIcon) { _, newValue in
                         NSApp.setActivationPolicy(newValue ? .regular : .accessory)
-                        if newValue {
+                        // After flipping the policy (either direction), macOS
+                        // deactivates the app. Re-raise the Settings window so
+                        // the user doesn't feel like the app disappeared.
+                        DispatchQueue.main.async {
                             NSApp.activate(ignoringOtherApps: true)
+                            NSApp.keyWindow?.makeKeyAndOrderFront(nil)
                         }
                     }
                 Toggle("Show in menu bar", isOn: $showMenuBar)


### PR DESCRIPTION
## Summary

Adds three toggles to Settings → Appearance:

- **Show in Dock** — flips `NSApp.setActivationPolicy` between `.regular` and `.accessory` at runtime, and on launch based on the stored `@AppStorage` value.
- **Show in menu bar** — binds `MenuBarExtra` visibility via `isInserted`.
- **Launch at login** — registers/unregisters the app via `SMAppService.mainApp`.

Dock and menu bar toggles are on by default (matching Apple's positive-phrasing convention — "Show in menu bar" in System Settings). Launch at login is off by default.

## Safeguard

Dock and menu bar toggles are mutually guarded: you can't turn off the last remaining surface. If only the Dock is visible, "Show in Dock" is disabled; same for the menu bar. This prevents the app from becoming completely inaccessible.

## UX notes

- Switching activation policy deactivates the app (standard macOS behavior), so the Settings window re-raises itself on the next runloop tick — otherwise it feels like the app disappeared.
- First enable of "Launch at login" may require approval in System Settings → General → Login Items; that state is surfaced as an inline hint under the toggle.

## Test plan

- [x] Toggle "Show in Dock" off — Dock icon disappears, menu bar icon stays, Settings window stays visible.
- [x] Toggle "Show in menu bar" off — menu bar icon disappears, Dock icon stays.
- [x] With one toggle off, the other is disabled (can't turn off both).
- [x] Relaunch app with Dock hidden — launches in accessory mode.
- [x] Enable "Launch at login", log out and back in — Hlopya starts automatically.
- [x] Disable "Launch at login" — app no longer auto-starts after logout/login.