### PR TITLE
feat: import existing audio files via button and drag-and-drop

### DIFF
--- a/Hlopya/Services/AudioImportService.swift
+++ b/Hlopya/Services/AudioImportService.swift
@@ -1,0 +1,152 @@
+import AVFoundation
+import UniformTypeIdentifiers
+import Foundation
+
+/// Converts arbitrary audio files into Hlopya session folders (mic.wav + system.wav + meta.json).
+final class AudioImportService {
+    var sessionManager: SessionManager?
+
+    static let supportedTypes: [UTType] = [
+        .audio, .mpeg4Audio, .mp3, .wav, .aiff,
+        UTType("public.flac") ?? .audio,
+        UTType("public.aac-audio") ?? .audio,
+    ].uniqued()
+
+    struct ImportFailure: Error {
+        let filename: String
+        let reason: String
+    }
+
+    // MARK: - Public
+
+    func importFiles(_ urls: [URL]) async -> (succeeded: Int, failed: [(filename: String, reason: String)]) {
+        var succeeded = 0
+        var failures: [(String, String)] = []
+
+        for (index, url) in urls.enumerated() {
+            do {
+                try await importSingle(url, batchIndex: index)
+                succeeded += 1
+            } catch let e as ImportFailure {
+                failures.append((e.filename, e.reason))
+            } catch {
+                failures.append((url.lastPathComponent, error.localizedDescription))
+            }
+        }
+
+        await MainActor.run { sessionManager?.loadSessions() }
+        return (succeeded, failures)
+    }
+
+    // MARK: - Private
+
+    private func importSingle(_ url: URL, batchIndex: Int) async throws {
+        let name = url.deletingPathExtension().lastPathComponent
+        let base = Session.dateFormatter.string(from: Date())
+        let sessionId = batchIndex == 0 ? "\(base)_import" : "\(base)_import-\(batchIndex)"
+        let sessionDir = Session.recordingsDirectory.appendingPathComponent(sessionId)
+
+        try FileManager.default.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+
+        do {
+            let micURL = sessionDir.appendingPathComponent("mic.wav")
+            let sysURL = sessionDir.appendingPathComponent("system.wav")
+
+            try await convertToWAV(inputURL: url, outputURL: micURL)
+
+            let asset = AVURLAsset(url: micURL)
+            let duration = try await asset.load(.duration)
+            try writeSilentWAV(at: sysURL, duration: CMTimeGetSeconds(duration))
+
+            let meta: [String: Any] = [
+                "title": name,
+                "status": SessionStatus.recorded.rawValue,
+                "participants": ["Me"],
+                "participant_names": [String: String](),
+                "meeting_with": "",
+                "duration": 0,
+            ]
+            let data = try JSONSerialization.data(withJSONObject: meta, options: .prettyPrinted)
+            try data.write(to: sessionDir.appendingPathComponent("meta.json"))
+        } catch {
+            try? FileManager.default.removeItem(at: sessionDir)
+            throw ImportFailure(filename: url.lastPathComponent, reason: error.localizedDescription)
+        }
+    }
+
+    private func convertToWAV(inputURL: URL, outputURL: URL) async throws {
+        let asset = AVURLAsset(url: inputURL)
+        guard let track = try await asset.loadTracks(withMediaType: .audio).first else {
+            throw ImportFailure(filename: inputURL.lastPathComponent, reason: "No audio track found")
+        }
+
+        let outputSettings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: 16_000,
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: false,
+        ]
+
+        let reader = try AVAssetReader(asset: asset)
+        let readerOutput = AVAssetReaderTrackOutput(track: track, outputSettings: outputSettings)
+        reader.add(readerOutput)
+
+        let writer = try AVAssetWriter(url: outputURL, fileType: .wav)
+        let writerInput = AVAssetWriterInput(mediaType: .audio, outputSettings: outputSettings)
+        writer.add(writerInput)
+
+        guard reader.startReading() else {
+            throw ImportFailure(filename: inputURL.lastPathComponent, reason: reader.error?.localizedDescription ?? "Read failed")
+        }
+        writer.startWriting()
+        writer.startSession(atSourceTime: .zero)
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            writerInput.requestMediaDataWhenReady(on: DispatchQueue(label: "hlopya.import")) {
+                while writerInput.isReadyForMoreMediaData {
+                    if let buf = readerOutput.copyNextSampleBuffer() {
+                        writerInput.append(buf)
+                    } else {
+                        writerInput.markAsFinished()
+                        writer.finishWriting { continuation.resume() }
+                        return
+                    }
+                }
+            }
+        }
+
+        if writer.status == .failed {
+            throw ImportFailure(filename: inputURL.lastPathComponent, reason: writer.error?.localizedDescription ?? "Write failed")
+        }
+    }
+
+    private func writeSilentWAV(at url: URL, duration: Double) throws {
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: 16_000,
+            channels: 1,
+            interleaved: true
+        )!
+        let frameCount = AVAudioFrameCount(max(duration * 16_000, 1))
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount)!
+        buffer.frameLength = frameCount
+        // Buffer memory is zeroed by default — silence.
+        let file = try AVAudioFile(
+            forWriting: url,
+            settings: format.settings,
+            commonFormat: .pcmFormatInt16,
+            interleaved: true
+        )
+        try file.write(from: buffer)
+    }
+}
+
+private extension Array where Element: Hashable {
+    func uniqued() -> [Element] {
+        var seen = Set<Element>()
+        return filter { seen.insert($0).inserted }
+    }
+}

--- a/Hlopya/ViewModels/AppViewModel.swift
+++ b/Hlopya/ViewModels/AppViewModel.swift
@@ -12,6 +12,7 @@ final class AppViewModel {
     let noteGeneration = NoteGenerationService()
     let obsidianExporter = ObsidianExporter()
     let vocabularyService = VocabularyService()
+    let audioImport = AudioImportService()
 
     // State
     var selectedSessionId: String?
@@ -42,6 +43,32 @@ final class AppViewModel {
 
     var selectedSession: Session? {
         sessionManager.sessions.first { $0.id == selectedSessionId }
+    }
+
+    init() {
+        audioImport.sessionManager = sessionManager
+    }
+
+    // MARK: - Import
+
+    func importAudio(urls: [URL]) async {
+        let (succeeded, failures) = await audioImport.importFiles(urls)
+
+        if failures.isEmpty {
+            let noun = succeeded == 1 ? "session" : "sessions"
+            audioSavedMessage = "Imported \(succeeded) \(noun). Click Transcribe to process."
+        } else if succeeded > 0 {
+            let names = failures.map(\.filename).joined(separator: ", ")
+            audioSavedMessage = "Imported \(succeeded), failed: \(names)"
+        } else {
+            let names = failures.map(\.filename).joined(separator: ", ")
+            audioSavedMessage = "Import failed: \(names)"
+        }
+
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(8))
+            if audioSavedMessage != nil { audioSavedMessage = nil }
+        }
     }
 
     // MARK: - Recording

--- a/Hlopya/Views/SessionListView.swift
+++ b/Hlopya/Views/SessionListView.swift
@@ -7,6 +7,7 @@ struct SessionListView: View {
     @Binding var showSystem: Bool
     @State private var sessionToDelete: Session?
     @State private var meetingWith: String = ""
+    @State private var isDragTargeted = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -155,6 +156,31 @@ struct SessionListView: View {
                 .background(showSystem ? Color.accentColor.opacity(0.12) : .clear)
                 .clipShape(RoundedRectangle(cornerRadius: 6))
 
+                // Import button
+                Button {
+                    let panel = NSOpenPanel()
+                    panel.allowsMultipleSelection = true
+                    panel.canChooseDirectories = false
+                    panel.allowedContentTypes = AudioImportService.supportedTypes
+                    panel.prompt = "Import"
+                    if panel.runModal() == .OK {
+                        Task { await vm.importAudio(urls: panel.urls) }
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "square.and.arrow.down")
+                            .font(.system(size: 12))
+                        Text("Import audio...")
+                            .font(.system(size: 12))
+                        Spacer()
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                }
+                .buttonStyle(.plain)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .disabled(vm.audioCapture.isRecording)
+
                 // Settings button
                 SettingsLink {
                     HStack(spacing: 6) {
@@ -216,6 +242,17 @@ struct SessionListView: View {
                 }
             }
             .listStyle(.sidebar)
+            .dropDestination(for: URL.self) { urls, _ in
+                Task { await vm.importAudio(urls: urls) }
+                return true
+            } isTargeted: { isDragTargeted = $0 }
+            .overlay {
+                if isDragTargeted {
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(Color.accentColor, lineWidth: 1.5)
+                        .allowsHitTesting(false)
+                }
+            }
         }
         .background(.ultraThinMaterial)
         .alert("Delete Recording?", isPresented: Binding(


### PR DESCRIPTION
## Summary

- Adds `AudioImportService` — converts any AVFoundation-readable format (m4a, mp3, aac, wav, flac, aiff) to 16 kHz mono PCM WAV via `AVAssetReader` + `AVAssetWriter`, writes a matching silent `system.wav`, and creates a `meta.json` with `status: recorded`. No external dependencies.
- Wires the service into `AppViewModel` with an `importAudio(urls:)` method that shows a success/failure banner.
- Adds two import triggers to `SessionListView`: a plain **Import audio...** button in the nav section (opens `NSOpenPanel`, disabled while recording), and a `.dropDestination` on the session list with an accent-colored border on hover.

Each imported file becomes a normal `.recorded` session — the existing per-session **Transcribe** button handles the rest.

## Test plan

- [ ] Click **Import audio...** → file picker opens filtered to audio types
- [ ] Pick one m4a → session appears with `NEW` badge and filename as title
- [ ] Drag audio file from Finder onto session list → blue border on hover, session created on drop
- [ ] Drop multiple files at once → one session per file, no id collisions
- [ ] Click **Transcribe** on imported session → parakeet runs normally
- [ ] Drop unsupported file type → banner shows failure, no broken folder in `~/recordings/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)