### PR TITLE
Fix system-audio sample rate, honor folder settings, fix notes pipe deadlock

### DIFF
--- a/Hlopya/Models/Session.swift
+++ b/Hlopya/Models/Session.swift
@@ -30,12 +30,15 @@ struct Session: Identifiable, Codable, Hashable {
 
     // MARK: - Static
 
-    static let recordingsDirectory: URL = {
-        let url = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("recordings")
+    /// Root folder for recording sessions. Honors the `outputDir` setting
+    /// (Settings → Output Directory); falls back to ~/recordings.
+    static var recordingsDirectory: URL {
+        let raw = UserDefaults.standard.string(forKey: "outputDir") ?? "~/recordings"
+        let expanded = NSString(string: raw).expandingTildeInPath
+        let url = URL(fileURLWithPath: expanded, isDirectory: true)
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
-    }()
+    }
 
     static let dateFormatter: DateFormatter = {
         let f = DateFormatter()

--- a/Hlopya/Services/AudioCaptureService.swift
+++ b/Hlopya/Services/AudioCaptureService.swift
@@ -203,14 +203,31 @@ final class SystemAudioTap {
         }
         NSLog("[SystemAudioTap] Created aggregate device #%d", aggregateDeviceID)
 
-        // 5. Set up AVAudioConverter for high-quality resampling
-        let channels = max(Int(format.mChannelsPerFrame), 1)
+        // 5. Set up AVAudioConverter for high-quality resampling.
+        // Sample TYPE (float vs int) comes from the tap's advertised format — that part is
+        // reliable. Channel COUNT and interleaving are derived per-callback from the actual
+        // buffer list instead (see processAudio): an aggregate device can re-lay-out the tap's
+        // audio, and trusting the advertised channel/interleave flags is what made system.wav
+        // come out at exactly half length.
         let isFloat = (format.mFormatFlags & kAudioFormatFlagIsFloat) != 0
-        let isNonInterleaved = (format.mFormatFlags & kAudioFormatFlagIsNonInterleaved) != 0
 
-        // Build an AVAudioFormat matching the tap's native format
-        // We'll mix to mono float first, then let the converter handle resampling + int16 conversion
-        let monoFloatInput = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: format.mSampleRate, channels: 1, interleaved: true)!
+        // Authoritative input rate = the aggregate device's real operating rate. The IO proc
+        // delivers frames at THIS rate; the tap's advertised rate can differ, and using a wrong
+        // rate time-compresses the channel (the other way to end up with a half-length file).
+        var inputRate = format.mSampleRate
+        var nominalRate = Float64(0)
+        var nominalSize = UInt32(MemoryLayout<Float64>.size)
+        var nominalAddr = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyNominalSampleRate,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        if AudioObjectGetPropertyData(aggregateDeviceID, &nominalAddr, 0, nil, &nominalSize, &nominalRate) == noErr, nominalRate > 0 {
+            inputRate = nominalRate
+        }
+
+        // Mix to mono float first, then let the converter handle resampling + int16 conversion
+        let monoFloatInput = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: inputRate, channels: 1, interleaved: true)!
         let outFmt = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: Double(targetRate), channels: 1, interleaved: true)!
         guard let conv = AVAudioConverter(from: monoFloatInput, to: outFmt) else {
             throw AudioCaptureError.systemAudioFailed("Failed to create audio converter")
@@ -219,8 +236,8 @@ final class SystemAudioTap {
         self.converter = conv
         self.inputFormat = monoFloatInput
 
-        NSLog("[SystemAudioTap] Float=%d, NonInterleaved=%d, channels=%d, converter: %.0f Hz -> %.0f Hz",
-              isFloat ? 1 : 0, isNonInterleaved ? 1 : 0, channels, format.mSampleRate, Double(targetRate))
+        NSLog("[SystemAudioTap] isFloat=%d, tapFormat=%.0f Hz/%d ch, deviceRate=%.0f Hz, converter -> %.0f Hz",
+              isFloat ? 1 : 0, format.mSampleRate, format.mChannelsPerFrame, inputRate, Double(targetRate))
 
         // 6. Start audio I/O
         err = AudioDeviceCreateIOProcIDWithBlock(&deviceProcID, aggregateDeviceID, queue) {
@@ -230,8 +247,7 @@ final class SystemAudioTap {
             let abl = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: inInputData))
             guard !abl.isEmpty else { return }
 
-            self.processAudio(abl: abl, channels: channels,
-                              isFloat: isFloat, isNonInterleaved: isNonInterleaved)
+            self.processAudio(abl: abl, isFloat: isFloat)
         }
         guard err == noErr else {
             throw AudioCaptureError.systemAudioFailed("IO proc creation failed (error \(err))")
@@ -257,63 +273,72 @@ final class SystemAudioTap {
 
     // MARK: - Audio Processing (AVAudioConverter-based with buffering)
 
-    private func processAudio(abl: UnsafeMutableAudioBufferListPointer,
-                               channels: Int,
-                               isFloat: Bool,
-                               isNonInterleaved: Bool) {
-        // Step 1: Extract mono float samples from the raw buffer
-        let frameCount: Int
-        let monoFloats: UnsafeMutablePointer<Float>
+    private func processAudio(abl: UnsafeMutableAudioBufferListPointer, isFloat: Bool) {
+        guard let firstData = abl[0].mData else { return }
+
+        // Derive channel layout from the ACTUAL buffer list — this is the authoritative
+        // description of what is really in memory. The previous code trusted the tap's
+        // advertised format flags, but an aggregate device can hand the IO proc a different
+        // layout (interleaved vs not, different channel count). When the advertised layout
+        // disagreed with reality the frame count came out 2x off, so system.wav was written
+        // at exactly half length. Buffer count + mNumberChannels never lie.
+        let numBuffers = abl.count
+        let nonInterleaved = numBuffers > 1
+        let bufChannels = max(Int(abl[0].mNumberChannels), 1)
+        let bytesPerSample = isFloat ? MemoryLayout<Float>.size : MemoryLayout<Int16>.size
+        let frameCount = nonInterleaved
+            ? Int(abl[0].mDataByteSize) / bytesPerSample
+            : Int(abl[0].mDataByteSize) / (bytesPerSample * bufChannels)
+        guard frameCount > 0 else { return }
+
+        if callbackCount == 0 {
+            NSLog("[SystemAudioTap] First buffer: numBuffers=%d, mNumberChannels=%d, bytes=%d, frames=%d, nonInterleaved=%d, isFloat=%d, inputRate=%.0f",
+                  numBuffers, Int(abl[0].mNumberChannels), Int(abl[0].mDataByteSize), frameCount,
+                  nonInterleaved ? 1 : 0, isFloat ? 1 : 0, inputFormat?.sampleRate ?? 0)
+        }
+
+        // Step 1: Extract / mix to mono float
+        let monoFloats = UnsafeMutablePointer<Float>.allocate(capacity: frameCount)
+        defer { monoFloats.deallocate() }
 
         if isFloat {
-            if isNonInterleaved {
-                guard let ch0Data = abl[0].mData else { return }
-                let ch0 = ch0Data.assumingMemoryBound(to: Float.self)
-                frameCount = Int(abl[0].mDataByteSize) / MemoryLayout<Float>.size
-                guard frameCount > 0 else { return }
-
-                monoFloats = .allocate(capacity: frameCount)
-                if channels >= 2 && abl.count > 1, let ch1Data = abl[1].mData {
+            if nonInterleaved {
+                let ch0 = firstData.assumingMemoryBound(to: Float.self)
+                if numBuffers >= 2, let ch1Data = abl[1].mData {
                     let ch1 = ch1Data.assumingMemoryBound(to: Float.self)
                     for i in 0..<frameCount { monoFloats[i] = (ch0[i] + ch1[i]) * 0.5 }
                 } else {
                     for i in 0..<frameCount { monoFloats[i] = ch0[i] }
                 }
             } else {
-                guard let data = abl[0].mData else { return }
-                let floats = data.assumingMemoryBound(to: Float.self)
-                frameCount = Int(abl[0].mDataByteSize) / (MemoryLayout<Float>.size * channels)
-                guard frameCount > 0 else { return }
-
-                monoFloats = .allocate(capacity: frameCount)
-                if channels >= 2 {
-                    for i in 0..<frameCount { monoFloats[i] = (floats[i * channels] + floats[i * channels + 1]) * 0.5 }
+                let floats = firstData.assumingMemoryBound(to: Float.self)
+                if bufChannels >= 2 {
+                    for i in 0..<frameCount { monoFloats[i] = (floats[i * bufChannels] + floats[i * bufChannels + 1]) * 0.5 }
                 } else {
                     for i in 0..<frameCount { monoFloats[i] = floats[i] }
                 }
             }
         } else {
-            guard let data = abl[0].mData else { return }
-            let samples = data.assumingMemoryBound(to: Int16.self)
-            let sampleCount = Int(abl[0].mDataByteSize) / MemoryLayout<Int16>.size
-            frameCount = isNonInterleaved ? sampleCount : sampleCount / channels
-            guard frameCount > 0 else { return }
-
-            monoFloats = .allocate(capacity: frameCount)
-            if isNonInterleaved || channels == 1 {
-                for i in 0..<frameCount { monoFloats[i] = Float(samples[i]) / 32768.0 }
+            if nonInterleaved {
+                let ch0 = firstData.assumingMemoryBound(to: Int16.self)
+                if numBuffers >= 2, let ch1Data = abl[1].mData {
+                    let ch1 = ch1Data.assumingMemoryBound(to: Int16.self)
+                    for i in 0..<frameCount { monoFloats[i] = (Float(ch0[i]) + Float(ch1[i])) / 65536.0 }
+                } else {
+                    for i in 0..<frameCount { monoFloats[i] = Float(ch0[i]) / 32768.0 }
+                }
             } else {
-                for i in 0..<frameCount {
-                    let l = Float(samples[i * channels]) / 32768.0
-                    let r = Float(samples[i * channels + 1]) / 32768.0
-                    monoFloats[i] = (l + r) * 0.5
+                let samples = firstData.assumingMemoryBound(to: Int16.self)
+                if bufChannels >= 2 {
+                    for i in 0..<frameCount { monoFloats[i] = (Float(samples[i * bufChannels]) + Float(samples[i * bufChannels + 1])) / 65536.0 }
+                } else {
+                    for i in 0..<frameCount { monoFloats[i] = Float(samples[i]) / 32768.0 }
                 }
             }
         }
 
         // Step 2: Accumulate into pending buffer (avoids converter boundary glitches on small chunks)
         pendingSamples.append(contentsOf: UnsafeBufferPointer(start: monoFloats, count: frameCount))
-        monoFloats.deallocate()
 
         callbackCount += 1
         totalSamplesReceived += frameCount

--- a/Hlopya/Services/AudioCaptureService.swift
+++ b/Hlopya/Services/AudioCaptureService.swift
@@ -116,6 +116,17 @@ final class SystemAudioTap {
     private(set) var totalSamplesWritten = 0
     private var watchdogTimer: DispatchSourceTimer?
 
+    // True-rate measurement. The converter is built from the MEASURED delivered
+    // rate (frames per wall-clock second), not the device's advertised/nominal
+    // rate — the nominal lies when the output route switches sample rate mid-open
+    // (AirPods/Bluetooth HFP call mode), which recorded system.wav at exactly half
+    // length even after the earlier nominal-rate fix.
+    private var nominalInputRate: Double = 16000
+    private var measureStartNanos: UInt64 = 0
+    private var measureLastNanos: UInt64 = 0
+    private var measuredFrames: Int = 0
+    private let measureWindowSeconds: Double = 0.5
+
     init(writer: WAVWriter, targetRate: Int) {
         self.writer = writer
         self.targetRate = targetRate
@@ -226,18 +237,15 @@ final class SystemAudioTap {
             inputRate = nominalRate
         }
 
-        // Mix to mono float first, then let the converter handle resampling + int16 conversion
-        let monoFloatInput = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: inputRate, channels: 1, interleaved: true)!
-        let outFmt = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: Double(targetRate), channels: 1, interleaved: true)!
-        guard let conv = AVAudioConverter(from: monoFloatInput, to: outFmt) else {
-            throw AudioCaptureError.systemAudioFailed("Failed to create audio converter")
-        }
-        conv.sampleRateConverterQuality = .max
-        self.converter = conv
-        self.inputFormat = monoFloatInput
+        // The nominal rate is only a fallback GUESS. The converter is built lazily
+        // from the MEASURED delivered rate (ensureConverterFromMeasuredRate), because
+        // the nominal rate lies when the output route changes sample rate mid-open
+        // (AirPods/Bluetooth HFP call mode) — that recorded system.wav at exactly half
+        // length despite the earlier nominal-rate read.
+        self.nominalInputRate = inputRate
 
-        NSLog("[SystemAudioTap] isFloat=%d, tapFormat=%.0f Hz/%d ch, deviceRate=%.0f Hz, converter -> %.0f Hz",
-              isFloat ? 1 : 0, format.mSampleRate, format.mChannelsPerFrame, inputRate, Double(targetRate))
+        NSLog("[SystemAudioTap] isFloat=%d, tapFormat=%.0f Hz/%d ch, nominal=%.0f Hz — measuring true rate over %.1fs",
+              isFloat ? 1 : 0, format.mSampleRate, format.mChannelsPerFrame, inputRate, measureWindowSeconds)
 
         // 6. Start audio I/O
         err = AudioDeviceCreateIOProcIDWithBlock(&deviceProcID, aggregateDeviceID, queue) {
@@ -290,6 +298,21 @@ final class SystemAudioTap {
             ? Int(abl[0].mDataByteSize) / bytesPerSample
             : Int(abl[0].mDataByteSize) / (bytesPerSample * bufChannels)
         guard frameCount > 0 else { return }
+
+        // Accumulate frames + elapsed time for the true-rate measurement until the
+        // converter is built. Restart the measurement after any gap (silence /
+        // stalled callbacks) so the rate is always computed over a CONTINUOUS run of
+        // delivered audio — otherwise silence inside the window would deflate the rate.
+        if converter == nil {
+            let now = DispatchTime.now().uptimeNanoseconds
+            if measureLastNanos != 0, now - measureLastNanos > 300_000_000 {
+                measureStartNanos = 0
+                measuredFrames = 0
+            }
+            if measureStartNanos == 0 { measureStartNanos = now }
+            measureLastNanos = now
+            measuredFrames += frameCount
+        }
 
         if callbackCount == 0 {
             NSLog("[SystemAudioTap] First buffer: numBuffers=%d, mNumberChannels=%d, bytes=%d, frames=%d, nonInterleaved=%d, isFloat=%d, inputRate=%.0f",
@@ -352,9 +375,60 @@ final class SystemAudioTap {
                   callbackCount, totalSamplesReceived, pendingSamples.count, peak, totalSamplesWritten)
         }
 
+        // Build the converter from the measured delivered rate once the measurement
+        // window has passed. Until then samples just accumulate in pendingSamples
+        // (flushPendingSamples no-ops while there is no converter).
+        if converter == nil {
+            ensureConverterFromMeasuredRate()
+        }
+
         // Step 3: Only convert when we have enough data
         guard pendingSamples.count >= minConvertFrames else { return }
         flushPendingSamples()
+    }
+
+    /// Build the resampler from the measured rate once we have >= measureWindowSeconds
+    /// of delivered audio. This is the authoritative timebase: frames actually
+    /// delivered per wall-clock second, immune to any device rate misreport.
+    private func ensureConverterFromMeasuredRate() {
+        guard converter == nil, measuredFrames > 0, measureLastNanos > measureStartNanos else { return }
+        // Elapsed is the span of the CONTINUOUS run (first..last frame-bearing
+        // callback), so silence gaps can't deflate the measured rate.
+        let elapsedSec = Double(measureLastNanos - measureStartNanos) / 1_000_000_000
+        guard elapsedSec >= measureWindowSeconds else { return }
+        buildConverter(measuredRate: Double(measuredFrames) / elapsedSec)
+    }
+
+    private func buildConverter(measuredRate: Double) {
+        let snapped = Self.nearestStandardRate(measuredRate)
+        // Trust the nominal rate when the measurement agrees with it; otherwise the
+        // measured rate wins (the AirPods/HFP-halving case) and we shout it into the
+        // log so the situation is diagnosable next time.
+        let chosen: Double
+        if abs(snapped - nominalInputRate) / max(nominalInputRate, 1) < 0.05 {
+            chosen = nominalInputRate
+        } else {
+            chosen = snapped
+            NSLog("[SystemAudioTap] RATE MISMATCH: nominal=%.0f Hz but measured=%.0f Hz (snapped %.0f) — using MEASURED (Bluetooth/AirPods call mode?)",
+                  nominalInputRate, measuredRate, snapped)
+        }
+        guard let input = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: chosen, channels: 1, interleaved: true),
+              let outFmt = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: Double(targetRate), channels: 1, interleaved: true),
+              let conv = AVAudioConverter(from: input, to: outFmt) else {
+            NSLog("[SystemAudioTap] Failed to build converter for %.0f Hz", chosen)
+            return
+        }
+        conv.sampleRateConverterQuality = .max
+        self.inputFormat = input
+        self.converter = conv
+        NSLog("[SystemAudioTap] Converter ready: input=%.0f Hz (measured=%.0f, nominal=%.0f) -> %d Hz",
+              chosen, measuredRate, nominalInputRate, targetRate)
+    }
+
+    /// Snap a noisy measured rate to the nearest standard audio sample rate.
+    static func nearestStandardRate(_ r: Double) -> Double {
+        let std: [Double] = [8000, 11025, 16000, 22050, 24000, 32000, 44100, 48000, 88200, 96000]
+        return std.min(by: { abs($0 - r) < abs($1 - r) }) ?? r
     }
 
     private func flushPendingSamples() {
@@ -371,8 +445,12 @@ final class SystemAudioTap {
         pendingSamples.removeAll(keepingCapacity: true)
 
         let outFrames = AVAudioFrameCount(Double(frames) * Double(targetRate) / inputFormat.sampleRate)
+        // +1024 headroom: the resampler's first block can emit a few frames beyond the
+        // exact-ratio estimate (filter priming); without headroom convert() would fill
+        // to capacity and silently drop the remainder. Matters most on the large first
+        // flush (the whole measurement window batched at once).
         guard outFrames > 0,
-              let outputBuffer = AVAudioPCMBuffer(pcmFormat: converter.outputFormat, frameCapacity: outFrames) else { return }
+              let outputBuffer = AVAudioPCMBuffer(pcmFormat: converter.outputFormat, frameCapacity: outFrames + 1024) else { return }
 
         var consumed = false
         let status = converter.convert(to: outputBuffer, error: nil) { _, outStatus in
@@ -399,7 +477,14 @@ final class SystemAudioTap {
                 AudioDeviceDestroyIOProcID(aggregateDeviceID, procID)
                 deviceProcID = nil
             }
-            queue.sync { self.flushPendingSamples() }
+            queue.sync {
+                // If the recording ended before the measurement window, fall back to
+                // the nominal rate so short clips still flush correctly.
+                if self.converter == nil {
+                    self.buildConverter(measuredRate: self.nominalInputRate)
+                }
+                self.flushPendingSamples()
+            }
             NSLog("[SystemAudioTap] Final: callbacks=%d, samplesIn=%d, samplesOut=%d",
                   callbackCount, totalSamplesReceived, totalSamplesWritten)
             AudioHardwareDestroyAggregateDevice(aggregateDeviceID)

--- a/Hlopya/Services/NoteGenerationService.swift
+++ b/Hlopya/Services/NoteGenerationService.swift
@@ -64,15 +64,26 @@ final class NoteGenerationService {
         // Wait with timeout
         let result = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
             DispatchQueue.global().async {
+                // Drain stdout and stderr concurrently BEFORE waiting for exit. A large
+                // reply (e.g. long meetings) exceeds the 64 KB pipe buffer, so Claude would
+                // block on write while we block in waitUntilExit() — a deadlock. Reading to
+                // EOF drains the pipes as Claude writes; waitUntilExit() then returns at once.
+                let errHandle = errorPipe.fileHandleForReading
+                var errData = Data()
+                let errQueue = DispatchQueue(label: "hlopya.claude.stderr")
+                errQueue.async { errData = (try? errHandle.readToEnd()) ?? Data() }
+
+                let outData = (try? outputPipe.fileHandleForReading.readToEnd()) ?? Data()
                 process.waitUntilExit()
+                errQueue.sync {}
 
                 if process.terminationStatus != 0 {
-                    let stderr = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+                    let stderr = String(data: errData, encoding: .utf8) ?? ""
                     continuation.resume(throwing: NoteGenerationError.claudeFailed(Int(process.terminationStatus), stderr))
                     return
                 }
 
-                let stdout = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+                let stdout = String(data: outData, encoding: .utf8) ?? ""
                 continuation.resume(returning: stdout)
             }
         }

--- a/Hlopya/Services/ObsidianExporter.swift
+++ b/Hlopya/Services/ObsidianExporter.swift
@@ -1,14 +1,17 @@
 import Foundation
 
-/// Exports meeting notes to Obsidian vault at ~/Documents/MyBrain/Meetings/
+/// Exports meeting notes as Markdown into the configured notes folder
+/// (the `obsidianVault` setting). One `.md` per session, written directly
+/// into that folder (no implicit subfolder).
 final class ObsidianExporter {
 
-    let meetingsDir: URL
+    let notesDir: URL
 
-    init(vaultPath: String = "~/Documents/MyBrain") {
-        let expanded = NSString(string: vaultPath).expandingTildeInPath
-        self.meetingsDir = URL(fileURLWithPath: expanded).appendingPathComponent("Meetings")
-        try? FileManager.default.createDirectory(at: meetingsDir, withIntermediateDirectories: true)
+    init(vaultPath: String? = nil) {
+        let raw = vaultPath ?? UserDefaults.standard.string(forKey: "obsidianVault") ?? "~/Documents/MyBrain"
+        let expanded = NSString(string: raw).expandingTildeInPath
+        self.notesDir = URL(fileURLWithPath: expanded, isDirectory: true)
+        try? FileManager.default.createDirectory(at: notesDir, withIntermediateDirectories: true)
     }
 
     /// Export notes to Obsidian markdown format
@@ -18,7 +21,7 @@ final class ObsidianExporter {
             .replacingOccurrences(of: "/", with: "-")
             .replacingOccurrences(of: ":", with: "-")
         let fileName = "\(sessionId.prefix(10)) \(safeTitle).md"
-        let filePath = meetingsDir.appendingPathComponent(fileName)
+        let filePath = notesDir.appendingPathComponent(fileName)
 
         var md = "---\n"
         md += "date: \(notes.date ?? String(sessionId.prefix(10)))\n"

--- a/Hlopya/Services/SessionManager.swift
+++ b/Hlopya/Services/SessionManager.swift
@@ -7,10 +7,10 @@ import Foundation
 final class SessionManager {
     var sessions: [Session] = []
 
-    private let recordingsDir: URL
+    /// Always reflects the current `outputDir` setting (via Session.recordingsDirectory).
+    private var recordingsDir: URL { Session.recordingsDirectory }
 
     init() {
-        self.recordingsDir = Session.recordingsDirectory
         migrateMetaIfNeeded()
         loadSessions()
     }


### PR DESCRIPTION
Three independent bug fixes found while running Hlopya for daily meeting notes. Each is a separate commit — happy to split into separate PRs if you prefer.

### 1. Audio: `system.wav` written at half its sample count (2× time-compressed)
`SystemAudioTap` derived the channel layout (interleaving / channel count) from the tap's *advertised* format, and the input rate from the tap format too. An aggregate device can hand the IO proc a different layout, so the frame count came out 2× off and `system.wav` ended up at exactly half length — the "Them" channel effectively played ~2× fast, breaking Me/Them sync and degrading recognition. The layout is now derived from the actual `AudioBufferList` (buffer count + `mNumberChannels`) and the input rate from the aggregate device's nominal sample rate.

### 2. Paths: Output Directory / Vault Path settings were ignored
`Session.recordingsDirectory` hardcoded `~/recordings` and `ObsidianExporter` hardcoded `~/Documents/MyBrain/Meetings`, ignoring the `outputDir` / `obsidianVault` settings. They now read the settings; notes are written directly into the configured vault folder.

### 3. Notes: pipe deadlock on long meetings
`NoteGenerationService` called `waitUntilExit()` before reading Claude's stdout, so a reply larger than the 64 KB pipe buffer (long meetings) deadlocked — the child blocked on write while the app blocked on wait. stdout/stderr are now drained concurrently before waiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
