### PR TITLE
Auto-prompt to record calls + app ignore-list

### DIFF
--- a/Hlopya/HlopyaApp.swift
+++ b/Hlopya/HlopyaApp.swift
@@ -25,6 +25,12 @@ struct HlopyaApp: App {
         if !defaults.bool(forKey: "showDockIcon") {
             NSApplication.shared.setActivationPolicy(.accessory)
         }
+        // Auto-prompt to record calls is on by default. The ignore-list starts
+        // empty — users add their dictation apps in Settings so those don't
+        // trigger a prompt.
+        if defaults.object(forKey: "autoPromptCalls") == nil {
+            defaults.set(true, forKey: "autoPromptCalls")
+        }
     }
 
     var body: some Scene {

--- a/Hlopya/Services/MeetingDetector.swift
+++ b/Hlopya/Services/MeetingDetector.swift
@@ -1,0 +1,214 @@
+import Foundation
+import CoreAudio
+import AppKit
+import Darwin
+
+/// Detects when a video call has likely started by watching which apps are
+/// using the microphone, and surfaces a "Record this call?" prompt.
+///
+/// Mechanism: Core Audio process objects (macOS 14.4+) — the SAME API family
+/// `AudioCaptureService` already uses for process taps. Reading the process list
+/// needs NO special permission (unlike creating a tap):
+///   - `kAudioHardwarePropertyProcessObjectList` → all audio process objects
+///   - per object: `kAudioProcessPropertyIsRunningInput` (mic in use?) +
+///     `kAudioProcessPropertyPID` → pid → `NSRunningApplication` → bundle id.
+///
+/// Noise control: a candidate app must hold the mic continuously for
+/// `sustainThreshold` seconds (filters short dictation bursts), and apps on the
+/// user's blacklist never trigger (add dictation apps there).
+@MainActor
+final class MeetingDetector {
+
+    struct DetectedApp: Equatable {
+        let bundleId: String
+        let name: String
+    }
+
+    /// Fired once when a likely call is detected.
+    var onCallDetected: ((DetectedApp) -> Void)?
+
+    /// Supplied by the owner so we never prompt while Hlopya is already recording.
+    var isRecordingProvider: () -> Bool = { false }
+
+    private var timer: Timer?
+    private let pollInterval: TimeInterval = 2.0
+    /// Continuous mic-hold required before prompting — filters dictation bursts.
+    private let sustainThreshold: TimeInterval = 8.0
+
+    /// bundleId → first time we saw it continuously holding the mic.
+    private var candidateSince: [String: Date] = [:]
+    /// Apps already prompted during the current mic session — don't nag twice.
+    private var alreadyPrompted: Set<String> = []
+
+    private let selfBundleId = Bundle.main.bundleIdentifier ?? "com.vadims.hlopya"
+
+    // MARK: - Lifecycle
+
+    func start() {
+        stop()
+        NSLog("[MeetingDetector] started (poll %.0fs, sustain %.0fs)", pollInterval, sustainThreshold)
+        timer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.tick() }
+        }
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+        candidateSince.removeAll()
+        alreadyPrompted.removeAll()
+    }
+
+    // MARK: - Poll loop
+
+    private func tick() {
+        // Respect the user toggle (defaults seeded true in HlopyaApp).
+        guard UserDefaults.standard.bool(forKey: "autoPromptCalls") else { return }
+
+        // Never prompt over our own recording.
+        guard !isRecordingProvider() else {
+            candidateSince.removeAll()
+            return
+        }
+
+        let micApps = appsUsingMicrophone()
+        let allMicIds = Set(micApps.map(\.bundleId))
+        let blacklist = Self.blacklistedBundleIds()
+
+        // Candidates = mic users that are neither us nor blacklisted.
+        let candidates = micApps.filter { $0.bundleId != selfBundleId && !blacklist.contains($0.bundleId) }
+        let candidateIds = Set(candidates.map(\.bundleId))
+
+        // Forget debounce state for apps that stopped using the mic.
+        candidateSince = candidateSince.filter { candidateIds.contains($0.key) }
+        // Allow re-prompting once an app fully releases the mic.
+        alreadyPrompted = alreadyPrompted.filter { allMicIds.contains($0) }
+
+        let now = Date()
+        for app in candidates where !alreadyPrompted.contains(app.bundleId) {
+            let since = candidateSince[app.bundleId] ?? now
+            candidateSince[app.bundleId] = since
+            if now.timeIntervalSince(since) >= sustainThreshold {
+                alreadyPrompted.insert(app.bundleId)
+                NSLog("[MeetingDetector] call candidate: %@ (%@)", app.name, app.bundleId)
+                onCallDetected?(app)
+                break // one prompt at a time
+            }
+        }
+    }
+
+    // MARK: - Core Audio: who is using the microphone
+
+    private func appsUsingMicrophone() -> [DetectedApp] {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyProcessObjectList,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        var dataSize: UInt32 = 0
+        var err = AudioObjectGetPropertyDataSize(AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &dataSize)
+        guard err == noErr, dataSize > 0 else { return [] }
+
+        let count = Int(dataSize) / MemoryLayout<AudioObjectID>.size
+        var processObjects = [AudioObjectID](repeating: AudioObjectID(kAudioObjectUnknown), count: count)
+        err = AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &dataSize, &processObjects)
+        guard err == noErr else { return [] }
+
+        var seen = Set<String>()
+        var result: [DetectedApp] = []
+        for obj in processObjects {
+            guard processIsRunningInput(obj), let pid = processPID(obj) else { continue }
+            guard let app = resolveApp(pid: pid) else { continue }
+            if seen.insert(app.bundleId).inserted {
+                result.append(app)
+            }
+        }
+        return result
+    }
+
+    private func processIsRunningInput(_ obj: AudioObjectID) -> Bool {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioProcessPropertyIsRunningInput,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var value: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        let err = AudioObjectGetPropertyData(obj, &addr, 0, nil, &size, &value)
+        return err == noErr && value != 0
+    }
+
+    private func processPID(_ obj: AudioObjectID) -> pid_t? {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioProcessPropertyPID,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var pid: pid_t = -1
+        var size = UInt32(MemoryLayout<pid_t>.size)
+        let err = AudioObjectGetPropertyData(obj, &addr, 0, nil, &size, &pid)
+        guard err == noErr, pid > 0 else { return nil }
+        return pid
+    }
+
+    // MARK: - pid → user-facing app
+
+    /// Resolve a pid to the owning *application*. Browser calls (Google Meet) run
+    /// the mic in a helper process (e.g. "Google Chrome Helper (Audio)") that is
+    /// not itself a listed application — so we climb parent pids to the real app.
+    private func resolveApp(pid: pid_t) -> DetectedApp? {
+        if let app = NSRunningApplication(processIdentifier: pid),
+           app.activationPolicy == .regular,
+           let bid = app.bundleIdentifier {
+            return DetectedApp(bundleId: bid, name: app.localizedName ?? bid)
+        }
+        return climbToApp(from: pid)
+    }
+
+    private func climbToApp(from pid: pid_t, maxDepth: Int = 6) -> DetectedApp? {
+        var current = pid
+        for _ in 0..<maxDepth {
+            guard let ppid = parentPID(of: current), ppid > 1 else { return nil }
+            if let app = NSRunningApplication(processIdentifier: ppid),
+               app.activationPolicy == .regular,
+               let bid = app.bundleIdentifier {
+                return DetectedApp(bundleId: bid, name: app.localizedName ?? bid)
+            }
+            current = ppid
+        }
+        return nil
+    }
+
+    private func parentPID(of pid: pid_t) -> pid_t? {
+        var info = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.stride
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
+        let rc = sysctl(&mib, u_int(mib.count), &info, &size, nil, 0)
+        guard rc == 0 else { return nil }
+        let ppid = info.kp_eproc.e_ppid
+        return ppid > 0 ? ppid : nil
+    }
+
+    // MARK: - Blacklist (UserDefaults, seeded with Handy in HlopyaApp)
+
+    static let defaultBlacklist: [String] = []
+
+    static func blacklistedBundleIds() -> Set<String> {
+        Set(UserDefaults.standard.stringArray(forKey: "callPromptBlacklist") ?? defaultBlacklist)
+    }
+
+    static func addToBlacklist(_ bundleId: String) {
+        var list = UserDefaults.standard.stringArray(forKey: "callPromptBlacklist") ?? defaultBlacklist
+        guard !list.contains(bundleId) else { return }
+        list.append(bundleId)
+        UserDefaults.standard.set(list, forKey: "callPromptBlacklist")
+        NSLog("[MeetingDetector] blacklisted %@", bundleId)
+    }
+
+    static func removeFromBlacklist(_ bundleId: String) {
+        var list = UserDefaults.standard.stringArray(forKey: "callPromptBlacklist") ?? defaultBlacklist
+        list.removeAll { $0 == bundleId }
+        UserDefaults.standard.set(list, forKey: "callPromptBlacklist")
+    }
+}

--- a/Hlopya/ViewModels/AppViewModel.swift
+++ b/Hlopya/ViewModels/AppViewModel.swift
@@ -32,6 +32,10 @@ final class AppViewModel {
     // Nub panel
     private var nubPanel: RecordingNubPanel?
 
+    // Call detection (auto-prompt to record meetings)
+    private let meetingDetector = MeetingDetector()
+    private var callPromptPanel: CallPromptPanel?
+
     // Detail data (loaded on selection)
     var detailTranscript: String?
     var detailTranscriptResult: TranscriptResult?
@@ -42,6 +46,14 @@ final class AppViewModel {
 
     var selectedSession: Session? {
         sessionManager.sessions.first { $0.id == selectedSessionId }
+    }
+
+    init() {
+        // Start watching for calls as soon as the app launches (lightweight
+        // Core Audio poll). Deferred so `self` is fully initialized first.
+        Task { @MainActor [weak self] in
+            self?.startMeetingDetector()
+        }
     }
 
     // MARK: - Recording
@@ -469,6 +481,51 @@ final class AppViewModel {
     private func hideNub() {
         nubPanel?.close()
         nubPanel = nil
+    }
+
+    // MARK: - Call Detection
+
+    func startMeetingDetector() {
+        meetingDetector.isRecordingProvider = { [weak self] in
+            self?.audioCapture.isRecording ?? false
+        }
+        meetingDetector.onCallDetected = { [weak self] app in
+            self?.showCallPrompt(for: app)
+        }
+        meetingDetector.start()
+    }
+
+    private func showCallPrompt(for app: MeetingDetector.DetectedApp) {
+        guard callPromptPanel == nil, !audioCapture.isRecording else { return }
+
+        let panel = CallPromptPanel(
+            appName: app.name,
+            onRecord: { [weak self] in
+                self?.dismissCallPrompt()
+                Task { @MainActor in await self?.startRecording() }
+            },
+            onDismiss: { [weak self] in
+                self?.dismissCallPrompt()
+            },
+            onBlacklist: { [weak self] in
+                MeetingDetector.addToBlacklist(app.bundleId)
+                self?.dismissCallPrompt()
+            }
+        )
+        callPromptPanel = panel
+        panel.orderFront(nil)
+
+        // Auto-dismiss if ignored, but only if this exact panel is still up.
+        Task { @MainActor [weak self, weak panel] in
+            try? await Task.sleep(for: .seconds(30))
+            guard let self, self.callPromptPanel === panel else { return }
+            self.dismissCallPrompt()
+        }
+    }
+
+    private func dismissCallPrompt() {
+        callPromptPanel?.close()
+        callPromptPanel = nil
     }
 }
 

--- a/Hlopya/Views/CallPromptPanel.swift
+++ b/Hlopya/Views/CallPromptPanel.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+import AppKit
+
+/// Floating prompt shown when MeetingDetector thinks a call has started.
+/// "Record this call?" with Record / Not now / Don't ask for this app.
+/// Mirrors RecordingNubPanel: borderless non-activating floating NSPanel.
+final class CallPromptPanel: NSPanel {
+
+    init(appName: String,
+         onRecord: @escaping () -> Void,
+         onDismiss: @escaping () -> Void,
+         onBlacklist: @escaping () -> Void) {
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 110),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        isFloatingPanel = true
+        level = .floating
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = true
+        isMovableByWindowBackground = true
+
+        // Top-right corner, just below the menu bar.
+        if let screen = NSScreen.main {
+            let x = screen.visibleFrame.maxX - 320 - 16
+            let y = screen.visibleFrame.maxY - 110 - 12
+            setFrameOrigin(NSPoint(x: x, y: y))
+        }
+
+        let content = CallPromptContent(
+            appName: appName,
+            onRecord: onRecord,
+            onDismiss: onDismiss,
+            onBlacklist: onBlacklist
+        )
+        let hosting = NSHostingView(rootView: content)
+        hosting.frame = NSRect(x: 0, y: 0, width: 320, height: 110)
+        contentView = hosting
+    }
+}
+
+private struct CallPromptContent: View {
+    let appName: String
+    let onRecord: () -> Void
+    let onDismiss: () -> Void
+    let onBlacklist: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: HlopSpacing.md) {
+            HStack(spacing: HlopSpacing.sm) {
+                Image(systemName: "mic.circle.fill")
+                    .font(.system(size: 22))
+                    .foregroundStyle(HlopColors.recordingBadge)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Record this call?")
+                        .font(HlopTypography.body).fontWeight(.semibold)
+                    Text("\(appName) is using your microphone")
+                        .font(HlopTypography.footnote)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 0)
+            }
+
+            HStack(spacing: HlopSpacing.sm) {
+                Button(action: onRecord) {
+                    Label("Record", systemImage: "record.circle")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+
+                Button("Not now", action: onDismiss)
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
+            }
+
+            Button(action: onBlacklist) {
+                Text("Don’t ask for \(appName)")
+                    .font(HlopTypography.footnote)
+                    .foregroundStyle(.tertiary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(HlopSpacing.md)
+        .frame(width: 320)
+        .background {
+            RoundedRectangle(cornerRadius: 14)
+                .fill(.ultraThinMaterial)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .stroke(Color.primary.opacity(0.12), lineWidth: 0.5)
+                )
+        }
+    }
+}

--- a/Hlopya/Views/SettingsView.swift
+++ b/Hlopya/Views/SettingsView.swift
@@ -1,5 +1,6 @@
 import ServiceManagement
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// App preferences
 struct SettingsView: View {
@@ -13,6 +14,8 @@ struct SettingsView: View {
     @AppStorage("setupComplete") private var setupComplete = false
     @AppStorage("showDockIcon") private var showDockIcon = true
     @AppStorage("showMenuBar") private var showMenuBar = true
+    @AppStorage("autoPromptCalls") private var autoPromptCalls = true
+    @State private var callBlacklist: [String] = []
     @State private var claudeCliPath: String? = nil
     @State private var isCheckingClaude = true
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
@@ -34,6 +37,39 @@ struct SettingsView: View {
                 Text("Automatically transcribe and generate AI notes when recording stops")
                     .font(HlopTypography.footnote)
                     .foregroundStyle(.tertiary)
+            }
+
+            Section("Auto-record calls") {
+                Toggle("Prompt to record when a call starts", isOn: $autoPromptCalls)
+                Text("When an app starts using your microphone (Zoom, Google Meet, Teams…), Hlopya offers to record. Detection runs locally and needs no extra permission.")
+                    .font(HlopTypography.footnote)
+                    .foregroundStyle(.tertiary)
+
+                if autoPromptCalls {
+                    ForEach(callBlacklist, id: \.self) { bid in
+                        HStack {
+                            Text(appDisplayName(for: bid))
+                                .font(HlopTypography.footnote)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Spacer()
+                            Button {
+                                MeetingDetector.removeFromBlacklist(bid)
+                                reloadBlacklist()
+                            } label: {
+                                Image(systemName: "minus.circle.fill")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                            .help("Stop ignoring this app")
+                        }
+                    }
+                    Button("Add App to Ignore List…") { addAppToBlacklist() }
+                        .controlSize(.small)
+                    Text("Ignored apps never trigger a prompt — add your dictation app, for example.")
+                        .font(HlopTypography.footnote)
+                        .foregroundStyle(.tertiary)
+                }
             }
 
             Section("Appearance") {
@@ -167,6 +203,7 @@ struct SettingsView: View {
         .frame(width: 450)
         .padding()
         .task {
+            reloadBlacklist()
             isCheckingClaude = true
             let path = await Task.detached {
                 let p = NoteGenerationService.findClaudeCLI()
@@ -174,6 +211,37 @@ struct SettingsView: View {
             }.value
             claudeCliPath = path
             isCheckingClaude = false
+        }
+    }
+
+    // MARK: - Call-prompt blacklist
+
+    private func reloadBlacklist() {
+        callBlacklist = MeetingDetector.blacklistedBundleIds().sorted()
+    }
+
+    /// Pretty name for a bundle id, e.g. "Zoom  ·  us.zoom.xos".
+    private func appDisplayName(for bundleId: String) -> String {
+        if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) {
+            let name = FileManager.default.displayName(atPath: url.path)
+            let trimmed = name.hasSuffix(".app") ? String(name.dropLast(4)) : name
+            return "\(trimmed)  ·  \(bundleId)"
+        }
+        return bundleId
+    }
+
+    private func addAppToBlacklist() {
+        let panel = NSOpenPanel()
+        panel.title = "Choose an app to ignore"
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.application]
+        panel.directoryURL = URL(fileURLWithPath: "/Applications")
+        if panel.runModal() == .OK, let url = panel.url,
+           let bid = Bundle(url: url)?.bundleIdentifier {
+            MeetingDetector.addToBlacklist(bid)
+            reloadBlacklist()
         }
     }
 }


### PR DESCRIPTION
## What

Auto-prompt to record calls. When an app starts using the microphone — the signal that a call has begun — Hlopya shows a small floating prompt offering to start recording. This addresses the common "I forgot to hit record" problem with Google Meet / Zoom.

## How it works

- **`MeetingDetector`** polls Core Audio process objects (`kAudioHardwarePropertyProcessObjectList`), reads `kAudioProcessPropertyIsRunningInput` + `kAudioProcessPropertyPID` per process, and resolves the PID to the owning app via `NSRunningApplication`. For browser calls (Google Meet runs the mic in a Chrome helper process), it climbs parent PIDs (`sysctl`) to resolve to the actual browser. This is the same Core Audio process-object API family already used for taps in `AudioCaptureService`, and reading the list needs **no extra permission** (unlike creating a tap).
- An **8-second continuous-use debounce** filters out short dictation / voice-search bursts.
- An **app ignore-list** (UserDefaults, starts empty) excludes apps that legitimately hold the mic (e.g. dictation tools) — editable in Settings, plus a "Don't ask for this app" button on the prompt itself.
- **`CallPromptPanel`** is a floating `NSPanel` (Record / Not now / Don't ask), mirroring the existing `RecordingNubPanel`.
- New Settings section **"Auto-record calls"**: on/off toggle (on by default) + ignore-list editor.

Record on the prompt calls the existing `startRecording()` — no changes to the recording pipeline.

## Scope

Purely additive — 2 new files + small hooks in `AppViewModel`, `HlopyaApp`, `SettingsView` (+131 / -0). macOS 14.4+ (process-object input properties).

## Testing

Tested live: the prompt appears ~8 s into a real Google Meet and Zoom call; pressing Record starts a normal recording. A dictation app added to the ignore-list stays silent.

## Note / possible follow-up

A browser-based call resolves to the browser bundle id (e.g. Google Chrome), so heavy non-call mic use in the browser could also prompt; the ignore-list / "Don't ask" button covers that. A camera-in-use cross-check could further disambiguate calls from dictation in a follow-up.
